### PR TITLE
Adjust some Chinese translation

### DIFF
--- a/src/main/resources/TheCursedMod/localization/zhs/CardStrings.json
+++ b/src/main/resources/TheCursedMod/localization/zhs/CardStrings.json
@@ -169,8 +169,8 @@
     "DESCRIPTION": "仪式 : 获得一瓶混沌药水。 NL 消耗。"
   },
   "TheCursedMod:FuryStrike": {
-    "NAME": "愤怒撞击",
-    "DESCRIPTION": "造成 !D! 点伤害。 NL 手牌中所有的攻击牌在本回合变成0费。"
+    "NAME": "愤怒打击",
+    "DESCRIPTION": "造成 !D! 点伤害。 NL 手牌中所有的打击牌在本回合变成0费。"
   },
   "TheCursedMod:Grudge": {
     "NAME": "怨恨",
@@ -288,7 +288,7 @@
     "UPGRADE_DESCRIPTION": "获得 [E] [E] 。 如果手牌中有诅咒牌, 额外获得  [E] 。 NL 消耗。"
   },
   "TheCursedMod:SpitefulStrike": {
-    "NAME": "恶意攻击",
+    "NAME": "恶意打击",
     "DESCRIPTION": "造成 !D! 点伤害。 NL 如果手牌中有诅咒牌, 获得 [E] [E] 。"
   },
   "TheCursedMod:SpreadPlague": {
@@ -308,11 +308,11 @@
     "DESCRIPTION": "获得 !M! 点敏捷. NL 在回合结束, 失去 !M! 点敏捷。"
   },
   "TheCursedMod:Strike_TheCursed": {
-    "NAME": "攻击",
+    "NAME": "打击",
     "DESCRIPTION": "造成 !D! 点伤害。"
   },
   "TheCursedMod:StunningStrike": {
-    "NAME": "昏迷打击",
+    "NAME": "昏迷攻击",
     "DESCRIPTION": "造成 !D! 点伤害。 NL 如果敌人意图攻击, 给予 !M! 层昏迷。 NL 消耗。"
   },
   "TheCursedMod:SurpriseAttack": {

--- a/src/main/resources/TheCursedMod/localization/zhs/CardStrings.json
+++ b/src/main/resources/TheCursedMod/localization/zhs/CardStrings.json
@@ -316,7 +316,7 @@
     "DESCRIPTION": "造成 !D! 点伤害。 NL 如果敌人意图攻击, 给予 !M! 层昏迷。 NL 消耗。"
   },
   "TheCursedMod:SurpriseAttack": {
-    "NAME": "意外打击",
+    "NAME": "意外攻击",
     "DESCRIPTION": "固有。 NL 造成 !D! 点伤害。 NL 抽 1 张牌。 NL 消耗。"
   },
   "TheCursedMod:TacticalStrike": {

--- a/src/main/resources/TheCursedMod/localization/zhs/UIStrings.json
+++ b/src/main/resources/TheCursedMod/localization/zhs/UIStrings.json
@@ -18,7 +18,7 @@
   },
   "TheCursedMod:EndlessStrikeTheme": {
     "TEXT": [
-      "[无尽攻击] 无限使用“攻击牌”. (初始遗物: 四叶草挂饰)"
+      "[无尽打击] 无限使用“打击牌”. (初始遗物: 四叶草挂饰)"
     ]
   },
   "TheCursedMod:HeavyMachineGunTheme": {


### PR DESCRIPTION
This is for adjusting translation for "Strike" word. It should be exactly "打击", to clearly represent the effect of "Fury Strike" card as well as Ironclad's "Perfected Strike" card.
@autumnLeaves0 please check whether anything looks weird or not.